### PR TITLE
close button stays in right top corner

### DIFF
--- a/frontend_nextjs/Components/select_students/StudentDetails.js
+++ b/frontend_nextjs/Components/select_students/StudentDetails.js
@@ -231,27 +231,42 @@ export default function StudentDetails(props) {
                 </div>
             }
 
-
-            <Row className="details-upper-layer nomargin">
+            <Row className="nomargin">
+                <Col xs="auto" className="name_big">
+                    {student["mandatory"] ? student["mandatory"]["first name"] : ""} {student["mandatory"] ? student["mandatory"]["last name"] : ""}
+                </Col>
+                <Col>
+                    <Hint message="Delete the student">
+                        <button className="delete-button" onClick={() => setDeletePopUpShow(true)}>
+                            <Image src={deleteIcon} className="delete-icon" />
+                        </button>
+                    </Hint>
+                </Col>
+                <Col />
+                <Col xs="auto" className="close-button">
+                    <Hint message="Close the details">
+                        <Image onClick={() => hideStudentDetails()} className="d-inline-block align-top"
+                               src={closeIcon} alt="close-icon" width="25px" height="25px" objectFit={'contain'} />
+                    </Hint>
+                </Col>
+            </Row>
+            <Row className="nomargin">
                 <Col md="auto">
-                    <Row className="nomargin">
-                        <Col xs="auto" className="name_big">
-                            {student["mandatory"] ? student["mandatory"]["first name"] : ""} {student["mandatory"] ? student["mandatory"]["last name"] : ""}
-                        </Col>
-                        <Col>
-                            <Hint message="Delete the student">
-                                <button className="delete-button" onClick={() => setDeletePopUpShow(true)}>
-                                    <Image src={deleteIcon} className="delete-icon" />
-                                </button>
-                            </Hint>
-                        </Col>
-                    </Row>
-                    <Row className="nomargin">
+                    <Row className="nomargin" style={{marginBottom: "15px"}}>
                         <ul className="nomargin nopadding">
                             {(student["skills"]) && student["skills"].map((skill, index) =>
                                 <li className="skill" style={{ display: "inline-block" }}
                                     key={index}>{skill["name"].toUpperCase()}</li>)}
                         </ul>
+                    </Row>
+                    <Row md="auto" className="decision nomargin">
+                        <GeneralInfo listelement={false} student={student} decision={getDecisionString(decision)} />
+                    </Row>
+                    <Row md="auto" className="nomargin">
+                        <Button className="send-email-button"
+                                onClick={() => setEmailPopUpShow(true)}>
+                            Send email
+                        </Button>
                     </Row>
                 </Col>
                 <Col />
@@ -270,12 +285,6 @@ export default function StudentDetails(props) {
                         <Col xs="auto" className="nopadding">
                             <Hint message="Suggest no">
                                 <button className="suggest-no-button suggest-button" onClick={() => suggest(0)}>No</button>
-                            </Hint>
-                        </Col>
-                        <Col xs="auto" className="close-button">
-                            <Hint message="Close the details">
-                                <Image onClick={() => hideStudentDetails()} className="d-inline-block align-top"
-                                    src={closeIcon} alt="close-icon" width="42px" height="42px" objectFit={'contain'} />
                             </Hint>
                         </Col>
                     </Row>
@@ -300,17 +309,8 @@ export default function StudentDetails(props) {
                     </Row>
                 </Col>
             </Row>
-            <Row className="remaining-height-details" md="auto" style={{}}>
+            <Row className="nomargin" md="auto" style={{}}>
                 <Col className="fill_height scroll-overflow">
-                    <Row md="auto" className="decision nomargin">
-                        <GeneralInfo listelement={false} student={student} decision={getDecisionString(decision)} />
-                    </Row>
-                    <Row md="auto" className="nomargin">
-                        <Button className="send-email-button"
-                            onClick={() => setEmailPopUpShow(true)}>
-                            Send email
-                        </Button>
-                    </Row>
 
                     <Row md="auto" className="h2-titles student-details-suggestions-line nomargin">
                         <Col md="auto" className="suggestions-title"><h2>Suggestions</h2></Col>

--- a/frontend_nextjs/Components/select_students/StudentDetails.js
+++ b/frontend_nextjs/Components/select_students/StudentDetails.js
@@ -232,8 +232,15 @@ export default function StudentDetails(props) {
             }
 
             <Row className="nomargin">
-                <Col xs="auto" className="name_big">
-                    {student["mandatory"] ? student["mandatory"]["first name"] : ""} {student["mandatory"] ? student["mandatory"]["last name"] : ""}
+                <Col xs="auto">
+                    <h1>{student["mandatory"] ? student["mandatory"]["first name"] : ""} {student["mandatory"] ? student["mandatory"]["last name"] : ""}</h1>
+                    <Row className="nomargin" style={{marginBottom: "15px"}}>
+                        <ul className="nomargin nopadding">
+                            {(student["skills"]) && student["skills"].map((skill, index) =>
+                                <li className="skill" style={{ display: "inline-block" }}
+                                    key={index}>{skill["name"].toUpperCase()}</li>)}
+                        </ul>
+                    </Row>
                 </Col>
                 <Col>
                     <Hint message="Delete the student">
@@ -250,15 +257,8 @@ export default function StudentDetails(props) {
                     </Hint>
                 </Col>
             </Row>
-            <Row className="nomargin">
+            <Row className="info-and-buttons nomargin">
                 <Col md="auto">
-                    <Row className="nomargin" style={{marginBottom: "15px"}}>
-                        <ul className="nomargin nopadding">
-                            {(student["skills"]) && student["skills"].map((skill, index) =>
-                                <li className="skill" style={{ display: "inline-block" }}
-                                    key={index}>{skill["name"].toUpperCase()}</li>)}
-                        </ul>
-                    </Row>
                     <Row md="auto" className="decision nomargin">
                         <GeneralInfo listelement={false} student={student} decision={getDecisionString(decision)} />
                     </Row>
@@ -269,7 +269,6 @@ export default function StudentDetails(props) {
                         </Button>
                     </Row>
                 </Col>
-                <Col />
                 <Col xs="auto" className="buttongroup-paddingtop">
                     <Row>
                         <Col xs="auto" className="nopadding">

--- a/frontend_nextjs/styles/select-students.css
+++ b/frontend_nextjs/styles/select-students.css
@@ -34,7 +34,7 @@
 }
 
 .close-button {
-    margin-top: 3px;
+    margin-top: 13px;
     padding: 0;
 }
 

--- a/frontend_nextjs/styles/studentDetails.css
+++ b/frontend_nextjs/styles/studentDetails.css
@@ -56,10 +56,6 @@
     margin-right: 4px;
 }
 
-.details-upper-layer {
-    margin: 0 0 0 20px;
-}
-
 .dropdown-decision {
     height: 100%;
     padding-top: 7px;
@@ -72,11 +68,6 @@
     width: 95%;
     font-size: 15px;
     padding-left: 7px;
-}
-
-.remaining-height-details {
-    margin-top: 30px;
-    margin-left: 20px;
 }
 
 .student-details-suggestions-line {
@@ -112,10 +103,8 @@
     border-left-color: lightgray;
 
     margin-left: 0;
-    padding-top: 15px;
-    padding-right: 25px;
-    padding-bottom: 25px;
     overflow-y: scroll;
+    padding: 15px 25px 25px 30px;
 }
 
 .backbutton-margin {
@@ -182,6 +171,8 @@
 
 .buttongroup-paddingtop{
     padding-top: 5px;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .margins-accordion {

--- a/frontend_nextjs/styles/studentDetails.css
+++ b/frontend_nextjs/styles/studentDetails.css
@@ -1,8 +1,3 @@
-.name_big {
-    font-size: 40px;
-    padding-left: 0;
-}
-
 .suggest-button {
     font-size: 13px;
     width: 80px;
@@ -169,10 +164,14 @@
     font-size: 15px;
 }
 
-.buttongroup-paddingtop{
-    padding-top: 5px;
-    padding-left: 0;
-    padding-right: 0;
+.info-and-buttons {
+    justify-content: space-between;
+    flex-wrap: wrap-reverse;
+}
+
+.buttongroup-paddingtop {
+    padding: 5pt 0 5pt 0;
+    margin-left: -3.5pt;
 }
 
 .margins-accordion {


### PR DESCRIPTION
In student details, when you made the screen smaller, the close icon jumped under the student name. This is fixed in this pr.