### PR TITLE
show reason as tooltip in participations projects

### DIFF
--- a/frontend_nextjs/Components/projects/AddStudentModal.js
+++ b/frontend_nextjs/Components/projects/AddStudentModal.js
@@ -25,7 +25,9 @@ export default function AddStudentModal(props) {
     const [skills, setSkills] = useState([])
     const [projectNeededSkills, setProjectNeededSkills] = useState([]);
     const [skillsLeft, setSkillsLeft] = useState([]);
+    const [reason, setReason] = useState("");
     const [options, setOptions] = useState([{ "value": "None", "label": "None" }])
+
 
     /**
      * This function gets called when props.selectedStudent or props.selectedProject changes. It finds the intersection
@@ -86,10 +88,16 @@ export default function AddStudentModal(props) {
                 .setBody({
                     "student_id": props.selectedStudent.id.split("/").pop(),
                     "project_id": props.selectedProject.id.split("/").pop(),
-                    "skill_name": selectedSkill.value === "None" ? "" : selectedSkill.value
+                    "skill_name": selectedSkill.value === "None" ? "" : selectedSkill.value,
+                    "reason": reason
                 })
                 .post()
         }
+    }
+
+    const handleChange = (event) => {
+        event.preventDefault();
+        setReason(event.target.value);
     }
 
     /**
@@ -104,8 +112,11 @@ export default function AddStudentModal(props) {
                     <Modal.Title>Add {props.selectedStudent["mandatory"]["first name"]} {props.selectedStudent["mandatory"]["last name"]} to {props.selectedProject.name}</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
+                 <h4>Why are you making this decision?</h4>
+                 <p>A reason is not required, but will open up discussion and help us and your fellow coaches to understand.</p>
+                    <input id="suggestin-reason" name="reason" type="text" className="fill_width suggestion-reason" onChange={handleChange} value={reason} placeholder="Your reason"/>
                     <div>
-                        For which skill requirement do you want to add {props.selectedStudent["mandatory"]["first name"]} {props.selectedStudent["mandatory"]["last name"]} to the project?
+                        <h4>For which skill requirement do you want to add {props.selectedStudent["mandatory"]["first name"]} {props.selectedStudent["mandatory"]["last name"]} to the project?</h4>
                     </div>
                     <SkillSelector selectedSkill={selectedSkill} setSelectedSkill={setSelectedSkill}
                         options={options}

--- a/frontend_nextjs/Components/projects/ParticipationCard.js
+++ b/frontend_nextjs/Components/projects/ParticipationCard.js
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import red_cross from "/public/assets/wrong.svg";
 import { api, Url } from "../../utils/ApiClient";
 import { getID } from "../../utils/string";
+import Hint from "../Hint";
 
 
 /**
@@ -16,6 +17,7 @@ import { getID } from "../../utils/string";
 export default function ParticipationCard(props) {
 
     const [student, setStudent] = useState({})
+    const [reason, setReason] = useState(props.participation.reason || "No reason was given");
     const [deletedCard, setDeletedCard] = useState(false);
 
     /**
@@ -50,17 +52,22 @@ export default function ParticipationCard(props) {
                 <Card className={"participation-card"} key={props.participation}>
                     <div className={"participation-div"}>
                         <Row>
-                            <Col className={"participation-info"}>
-                                <div className={"participation-name"}>
-                                    {(Object.keys(student).length) ? (`${student["mandatory"]["first name"]} ${student["mandatory"]["last name"]}`) : null}
-                                </div>
-                                <SkillCard number={0} skill_name={props.participation.skill} />
-                            </Col>
+                            <Hint message={reason}>
+                                <Col className={"participation-info"}>
+                                    <div className={"participation-name"}>
+                                        {(Object.keys(student).length) ? (`${student["mandatory"]["first name"]} ${student["mandatory"]["last name"]}`) : null}
+                                    </div>
+                                    <SkillCard number={0} skill_name={props.participation.skill} />
+                                </Col>
+                            </Hint>
                             <Col xs={"auto"} className={"participation-remove-student"}>
                                 <div className={"participation-delete"}>
-                                    <Image alt={"delete student from project button"} onClick={deleteStudentFromProject} src={red_cross} width={25} height={25} />
+                                    <Hint message="Remove from this project">
+                                        <Image alt={"delete student from project button"} onClick={deleteStudentFromProject} src={red_cross} width={25} height={25} />
+                                    </Hint>
                                 </div>
                             </Col>
+                            
                         </Row>
                     </div>
 


### PR DESCRIPTION
added the option to add a reason to a participation
Fixes #432

we needed a way to show the reason of a participation in projects 
I made it a tooltip, because I didn't want to directly show that string of information for every participation
Fixes #497 