### PR TITLE
removed whitespace under email bottom bar + fixed skills position bug

### DIFF
--- a/frontend_nextjs/Components/students/GeneralInfo.js
+++ b/frontend_nextjs/Components/students/GeneralInfo.js
@@ -96,9 +96,19 @@ export default function GeneralInfo(props) {
       // add the decision of the student to the general info
       rows.push(
         <Row key={"Decision"} className="question-answer-row">
-          <Col md="auto" className="info-titles">Decision: <b>{decision}</b></Col>
+          <Col md="auto" className="info-titles">Decision</Col>
+          <Col md="auto" className="info-answers">{decision}</Col>
         </Row>
       )
+
+      if (props.elementType === "emailstudents") {
+        rows.push(
+          <Row key={"email_sent"} className="question-answer-row">
+            <Col md="auto" className="info-titles">Email sent</Col>
+            <Col md="auto" className="info-answers">{props.student["email_sent"] ? "Yes" : "No"}</Col>
+          </Row>
+        )
+      }
 
       return rows;
     }

--- a/frontend_nextjs/Components/students/StudentListAndFilters.js
+++ b/frontend_nextjs/Components/students/StudentListAndFilters.js
@@ -20,7 +20,7 @@ export default function StudentList(props) {
 
   const router = useRouter();
 
-  const listheights = { "students": "195px", "emailstudents": "264px" } // The custom height for the studentlist for the page of key
+  const listheights = { "students": "178px", "emailstudents": "245px" } // The custom height for the studentlist for the page of key
 
   // These constants are initialized empty, the data will be inserted in useEffect
   const [studentUrls, setStudentUrls] = useState([]);

--- a/frontend_nextjs/Components/students/StudentListelement.js
+++ b/frontend_nextjs/Components/students/StudentListelement.js
@@ -165,12 +165,6 @@ export default function StudentListelement(props) {
       <Row id="info" className="info">
         <GeneralInfo listelement={true} elementType={props.elementType} student={props.student}
                      decision={getDecisionString(props.student.decision)} />
-        {props.elementType === "emailstudents" ?
-          <Row key={"email_sent"} className="question-answer-row">
-            <Col md="auto" className="info-titles">Email sent</Col>
-            <Col md="auto" className="info-answers">{props.student["email_sent"] ? "Yes" : "No"}</Col>
-          </Row> : <></>
-        }
         <Col />
         <Col id="skills" align="right" className="skills" sm="auto">
           <ul className="nomargin">

--- a/frontend_nextjs/pages/students.js
+++ b/frontend_nextjs/pages/students.js
@@ -38,7 +38,7 @@ export default function Students() {
 
     return (
 
-        <Row style={{height: "calc(100vh - 86px)"}}>
+        <Row style={{height: "calc(100vh - 66px)"}}>
 
             {
                 fullView &&


### PR DESCRIPTION
This pr does:
1. removing the whitespace under the email bottom bar in the students tab.
2. fixed the skills position in the sudentListElement when opening the email bottom bar, the skills jumped to the next line before this pr.