### PR TITLE
remove /editions/{year}/users endpoint

### DIFF
--- a/backend/app/models/edition.py
+++ b/backend/app/models/edition.py
@@ -63,7 +63,6 @@ class EditionOutExtended(BaseModel):
             the kwargs in "data" are used to initialize the attributes of this class
         """
         data["uri"] = config.api_url + "editions/" + str(data["year"])
-        data["users"] = f"{config.api_url}editions/{data['year']}/users"
         data["students"] = f"{config.api_url}editions/{data['year']}/students"
         data["projects"] = f"{config.api_url}editions/{data['year']}/projects"
         data["questiontags"] = f"{config.api_url}editions/{data['year']}/questiontags"

--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -26,7 +26,7 @@ from app.models.question_tag import (QuestionTag, QuestionTagCreate,
 from app.models.skill import StudentSkill
 from app.models.student import DecisionOption, Student
 from app.models.suggestion import Suggestion, SuggestionOption
-from app.models.user import User, UserRole
+from app.models.user import UserRole
 from app.utils.checkers import EditionChecker, RoleChecker
 from fastapi import APIRouter, Body, Depends
 from fastapi_jwt_auth import AuthJWT
@@ -154,22 +154,6 @@ async def update_edition(year: int, edition: Edition = Body(...), role: RoleChec
         setattr(result, key, value)
     await update(result, session)
     return EditionOutSimple.parse_raw(result.json()).uri
-
-
-@router.get("/{year}/users", response_description="Users retrieved")
-async def get_edition_users(year: int, role: RoleChecker(UserRole.COACH) = Depends(), session: AsyncSession = Depends(get_session)):
-    """get_users get all the User instances from the database in edition with given year
-
-    :return: list of users
-    :rtype: dict
-    """
-
-    edition_coaches = await read_all_where(EditionCoach, EditionCoach.edition == year, session=session)
-    user_ids = [coach.coach_id for coach in edition_coaches]
-    # get the admins
-    admins = await read_all_where(User, User.role == UserRole.ADMIN, session=session)
-    user_ids += [admin.id for admin in admins]
-    return [f"{config.api_url}users/{str(id)}" for id in set(user_ids)]
 
 
 @router.get("/{year}/students", dependencies=[Depends(RoleChecker(UserRole.COACH))], response_description="Students retrieved")

--- a/backend/app/tests/test_routers/test_editions.py
+++ b/backend/app/tests/test_routers/test_editions.py
@@ -100,7 +100,6 @@ class TestEditions(TestBase):
             "year": self.edition.year,
             "name": self.edition.name,
             "description": self.edition.description,
-            "users": f"{config.api_url}editions/{self.edition.year}/users",
             "students": f"{config.api_url}editions/{self.edition.year}/students",
             "projects": f"{config.api_url}editions/{self.edition.year}/projects",
             "questiontags": f"{config.api_url}editions/{self.edition.year}/questiontags"
@@ -108,28 +107,6 @@ class TestEditions(TestBase):
         for user_title in allowed_users:
             edition_data_from_response = json.loads(responses.get(user_title).content)
             self._assert_edition_equal(expected_edition_data, edition_data_from_response)
-
-    async def test_get_edition_users(self):
-        """Test GET /editions/{year}/users"""
-        users = await read_all_where(User, User.active, User.approved, User.disabled == False, session=self.session)
-        for user in users:
-            editionCoach = EditionCoach(edition=self.edition.year, coach_id=user.id)
-            await update(editionCoach, self.session)
-
-        # Send request
-        path = f'/editions/{self.edition.year}/users'
-        allowed_users: Set[str] = await self.get_users_by([UserRole.ADMIN, UserRole.COACH])
-        responses: Dict[str, Response] = await self.auth_access_request_test(Request.GET, path, allowed_users)
-
-        test_users_ids = [user.id for user in users]
-        test_users_ids.sort()
-
-        # Compare response edition data with expected edition data
-        for user_title in allowed_users:
-            edition_data_from_response = json.loads(responses.get(user_title).content)
-            response_ids = [int(user_url.split('/')[-1]) for user_url in edition_data_from_response]
-            response_ids.sort()
-            self.assertEqual(test_users_ids, response_ids, f"Returned users of edition {self.edition.year} don't match expected value")
 
     async def test_get_edition_students(self):
         """Test GET /editions/{year}/students"""

--- a/backend/app/tests/test_routers/test_editions.py
+++ b/backend/app/tests/test_routers/test_editions.py
@@ -3,13 +3,13 @@ from typing import Dict, Set, List
 import uuid
 from httpx import Response
 from app.config import config
-from app.crud import read_all_where, read_where, update
+from app.crud import read_where, update
 from app.models.project import Project
-from app.models.user import User, UserRole
+from app.models.user import UserRole
 from app.tests.test_base import TestBase, Request
 from app.tests.utils_for_tests.EditionGenerator import EditionGenerator
 from app.tests.utils_for_tests.SkillGenerator import SkillGenerator
-from app.models.edition import Edition, EditionCoach
+from app.models.edition import Edition
 from app.tests.utils_for_tests.StudentGenerator import StudentGenerator
 from app.tests.utils_for_tests.ProjectGenerator import ProjectGenerator
 from app.models.participation import Participation


### PR DESCRIPTION
I assume the "users" field of EditionOutExtended isn't used, since the endpoint isn't used, so I removed that too.