### PR TITLE
slight studentlistelement improvement for smaller screens

### DIFF
--- a/frontend_nextjs/Components/students/StudentListelement.js
+++ b/frontend_nextjs/Components/students/StudentListelement.js
@@ -147,24 +147,25 @@ export default function StudentListelement(props) {
         <Col id="name" className="name" xs="auto">
           {props.student["mandatory"]["first name"]} {props.student["mandatory"]["last name"]}
         </Col>
-        <Col md="auto" className="student-listelement-icon">
-          {(props.student["mandatory"]["alumni"] === "yes") &&
-            <Hint message="Student claims to be an alumni">
-              <Image src={alumniIcon} width="25pt" height="35pt"/>
-            </Hint>
-          }
+        <Col className="icons-container">
+          <div className="student-listelement-icon">
+            {(props.student["mandatory"]["alumni"] === "yes") &&
+              <Hint message="Student claims to be an alumni">
+                <Image src={alumniIcon} width="25pt" height="35pt"/>
+              </Hint>
+            }
+          </div>
+          <div className="student-listelement-icon">
+            {(props.student["mandatory"]["student-coach"] === "yes") &&
+              <Hint message="applied to be student coach">
+                <Image src={studCoachIcon} width="25px" height="35px"/>
+              </Hint>
+            }
+          </div>
+        {/*<Col id="practical-problems" className="practical-problems" xs="auto">*/}
+        {/* if practical problems get implemented, this is where it should be shown */}
+        {/*</Col>*/}
         </Col>
-        <Col md="auto" className="student-listelement-icon">
-          {(props.student["mandatory"]["student-coach"] === "yes") &&
-            <Hint message="applied to be student coach">
-              <Image src={studCoachIcon} width="25px" height="35px"/>
-            </Hint>
-          }
-        </Col>
-        <Col id="practical-problems" className="practical-problems" xs="auto">
-          {/* if practical problems gets implemented, this is where it should be shown */}
-        </Col>
-        <Col />
         <Col xs="auto" className="nopadding">
           <Row xs="auto" className="nomargin">
             <Col className="suggestions" xs="auto">Suggestions:</Col>
@@ -177,7 +178,6 @@ export default function StudentListelement(props) {
       <Row id="info" className="info">
         <GeneralInfo listelement={true} elementType={props.elementType} student={props.student}
                      decision={getDecisionString(props.student.decision)} />
-        <Col />
         <Col id="skills" align="right" className="skills" sm="auto">
           <ul className="nomargin">
             {getSkills()}

--- a/frontend_nextjs/styles/studentListelement.css
+++ b/frontend_nextjs/styles/studentListelement.css
@@ -117,8 +117,7 @@
 }
 
 .upper-layer {
-    margin: 0;
-    margin-right: 5px;
+    margin: 0 5px 0 0;
 }
 
 .nomargin {

--- a/frontend_nextjs/styles/studentListelement.css
+++ b/frontend_nextjs/styles/studentListelement.css
@@ -103,7 +103,6 @@
 
 .skills {
     margin-top: 10px;
-    margin-right: 7px;
     padding: 0;
     align-self: end;
 }

--- a/frontend_nextjs/styles/studentListelement.css
+++ b/frontend_nextjs/styles/studentListelement.css
@@ -114,6 +114,7 @@
 
 .info {
     margin-left: 0;
+    justify-content: space-between;
 }
 
 .upper-layer {

--- a/frontend_nextjs/styles/studentListelement.css
+++ b/frontend_nextjs/styles/studentListelement.css
@@ -118,6 +118,7 @@
 
 .upper-layer {
     margin: 0;
+    margin-right: 5px;
 }
 
 .nomargin {

--- a/frontend_nextjs/styles/students.css
+++ b/frontend_nextjs/styles/students.css
@@ -103,3 +103,7 @@
     height: 35px;
     margin-right: 5px;
 }
+
+.icons-container > * {
+    display: inline;
+}


### PR DESCRIPTION
StudentListelements became quite big with lot's of open space when they were small. This pull request improves this slightly but it's not super great.

Before:
![image](https://user-images.githubusercontent.com/63423344/169669392-cd5da2fb-a8d8-45e3-b45e-67bf641a12ca.png)
After:
![image](https://user-images.githubusercontent.com/63423344/169669415-b754029d-58b9-4c21-8f80-206afcb079d9.png)
